### PR TITLE
Create FromDuration(time.Duration) convenience factory.

### DIFF
--- a/jsonutil.go
+++ b/jsonutil.go
@@ -12,6 +12,12 @@ type Duration struct {
 	time.Duration
 }
 
+// FromDuration is a convenience factory to create a Duration instance from the
+// given time.Duration value.
+func FromDuration(d time.Duration) Duration {
+	return Duration{d}
+}
+
 // MarshalJSON implements the json.Marshaler interface. The duration is a quoted-string in the format accepted by time.ParseDuration and returned by time.Duration.String.
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + d.String() + `"`), nil

--- a/jsonutil_test.go
+++ b/jsonutil_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/vrischmann/jsonutil"
 )
 
+func TestFromDuration(t *testing.T) {
+	dur := 10 * time.Second
+	require.Equal(t, jsonutil.FromDuration(dur).Duration, dur)
+}
+
 func TestMarshalJSON(t *testing.T) {
 	d := jsonutil.Duration{time.Second * 10}
 	data, err := d.MarshalJSON()


### PR DESCRIPTION
This is to reduce the level of boilerplate involved when doing a proper, vet-conform instantiation as in

`d := jsonutil.Duration{Duration: 10 * time.Second}`

I found `FromDuration` to improve readability. Let me know if you think this is worthwhile adding.